### PR TITLE
:sparkles: feature: add common response dto

### DIFF
--- a/src/main/java/com/praise/push/common/dto/ResponseDto.java
+++ b/src/main/java/com/praise/push/common/dto/ResponseDto.java
@@ -1,0 +1,33 @@
+package com.praise.push.common.dto;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public record ResponseDto<T>(T data) {
+    /**
+     * returns http ok(200) response with body data
+     */
+    public static <T> ResponseEntity<T> ok(T data) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(data);
+    }
+
+    /**
+     * returns http created(201) response with body data
+     */
+    public static <T> ResponseEntity<T> created(T data) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(data);
+    }
+
+    /**
+     * returns http no content(204) response with empty body data
+     */
+    public static ResponseEntity<Void> noContent() {
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .build();
+    }
+}

--- a/src/main/java/com/praise/push/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/praise/push/common/error/GlobalExceptionHandler.java
@@ -1,32 +1,32 @@
 package com.praise.push.common.error;
 
+import com.praise.push.common.ErrorCode;
+import com.praise.push.common.error.dto.ErrorResponseDto;
 import com.praise.push.common.monitoring.MonitoringProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.sql.SQLException;
+
+@Slf4j
 @RequiredArgsConstructor
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     private final MonitoringProvider monitoringProvider;
 
-    @ExceptionHandler(RuntimeException.class)
-    public ResponseEntity<String> handleRuntimeException(final RuntimeException exception) {
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body("RuntimeException Handler: " + exception.getMessage());
-    }
-
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(final Exception exception, final HttpServletRequest request) {
+    public ResponseEntity<ErrorResponseDto> handleException(
+            final Exception exception,
+            final HttpServletRequest request
+    ) {
+        log.error("Exception: {}, Request URI: {}", exception.getMessage(), request.getRequestURL());
         monitoringProvider.push(exception, request);
 
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body("Exception Handler: " + exception.getMessage());
+        return ErrorResponseDto.build(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/praise/push/common/error/dto/ErrorResponseDto.java
+++ b/src/main/java/com/praise/push/common/error/dto/ErrorResponseDto.java
@@ -1,0 +1,48 @@
+package com.praise.push.common.error.dto;
+
+import com.praise.push.common.ErrorCode;
+import lombok.Builder;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record ErrorResponseDto(
+        LocalDateTime timestamp,
+        Integer status,
+        String code,
+        String message
+) {
+
+    /**
+     * returns error response with ErrorCode
+     */
+    public static ResponseEntity<ErrorResponseDto> build(ErrorCode errorCode) {
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getErrorCode())
+                .message(errorCode.getErrorMessage())
+                .build();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponseDto);
+    }
+
+    /**
+     * returns error response with ErrorCode and custom error message
+     */
+    public static ResponseEntity<ErrorResponseDto> build(ErrorCode errorCode, String message) {
+        ErrorResponseDto errorResponseDto = ErrorResponseDto.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getHttpStatus().value())
+                .code(errorCode.getErrorCode())
+                .message(message)
+                .build();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(errorResponseDto);
+    }
+}


### PR DESCRIPTION
- Resolved: #39 

<br>

- 공통 응답, 에러 응답 설계
- 에러 응답의 경우 ErrorCode를 통해 만들거나, ErrorCode와 Custom Error Message를 통해 만들 수 있는 static 메서드로 정의했습니다.
- 공통 응답과 에러 응답 모두 Java의 Record를 이용해서 구현했습니다.
  - 모든 필드가 final(상수)라는 점
  - class에서 사용할 때보다 불필요한 것들은 Record에서 자동으로 만들어주기 때문에 편리함
  - 응답 틀이기 때문에 바인딩 후에 변경될 일이 없기 때문에 더 간단한 Record를 사용했습니다.

<br>

### Reference
- [ResponseDto](https://github.com/depromeet/street-drop-server/blob/dev/backend/streetdrop-api/src/main/java/com/depromeet/common/dto/ResponseDto.java)
- [ErrorResponseDto](https://github.com/depromeet/street-drop-server/blob/dev/backend/streetdrop-api/src/main/java/com/depromeet/common/error/dto/ErrorResponseDto.java)