### PR TITLE
:sparkles: feature: implement create comment

### DIFF
--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -2,8 +2,10 @@ package com.praise.push.adapter.in.web;
 
 import com.praise.push.application.port.in.CommentUseCase;
 import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +24,7 @@ class CommentController {
     ) {
         commentUseCase.createComment(command, postId);
 
-        return ResponseDto.noContent();
+        return ResponseDto.noContent(); // TODO: replace created(201) with Empty Body
     }
 
     @DeleteMapping("/comments/{commentId}")
@@ -30,5 +32,16 @@ class CommentController {
         commentUseCase.deleteComment(commentId);
 
         return ResponseDto.noContent();
+    }
+
+    @GetMapping("/posts/{postId}/comments")
+    ResponseEntity<Page<CommentSimpleResponseDto>> getComments(
+        @PathVariable Long postId,
+        @RequestParam(value = "page", defaultValue = "0") Integer page,
+        @RequestParam(value = "size", defaultValue = "24") Integer size
+    ) {
+        Page<CommentSimpleResponseDto> comments = commentUseCase.getComments(postId, page, size);
+
+        return ResponseDto.ok(comments);
     }
 }

--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -1,10 +1,27 @@
 package com.praise.push.adapter.in.web;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.praise.push.application.port.in.CommentUseCase;
+import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.common.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@RequestMapping("/praise-push/api/v1")
+@RequiredArgsConstructor
 @RestController
+@RequestMapping("/praise-up/api/v1")
 class CommentController {
 
+    private final CommentUseCase commentUseCase;
+
+    @PostMapping("/posts/{postId}/comments")
+    ResponseEntity<Void> createComment(
+        // TODO: uploaded image file
+        @RequestBody CreateCommentCommand command,
+        @PathVariable Long postId
+    ) {
+        commentUseCase.createComment(command, postId);
+
+        return ResponseDto.noContent();
+    }
 }

--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -25,7 +25,7 @@ class CommentController {
     ) {
         commentUseCase.createComment(command, postId);
 
-        return ResponseDto.noContent(); // TODO: replace created(201) with Empty Body
+        return ResponseDto.created();
     }
 
     @GetMapping("/comments/{commentId}")

--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -2,6 +2,7 @@ package com.praise.push.adapter.in.web;
 
 import com.praise.push.application.port.in.CommentUseCase;
 import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.application.port.in.dto.CommentDetailResponseDto;
 import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,13 @@ class CommentController {
         commentUseCase.createComment(command, postId);
 
         return ResponseDto.noContent(); // TODO: replace created(201) with Empty Body
+    }
+
+    @GetMapping("/comments/{commentId}")
+    ResponseEntity<?> getComments(@PathVariable Long commentId) {
+        CommentDetailResponseDto comment = commentUseCase.getComment(commentId);
+
+        return ResponseDto.ok(comment);
     }
 
     @DeleteMapping("/comments/{commentId}")

--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -24,4 +24,11 @@ class CommentController {
 
         return ResponseDto.noContent();
     }
+
+    @DeleteMapping("/comments/{commentId}")
+    ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+        commentUseCase.deleteComment(commentId);
+
+        return ResponseDto.noContent();
+    }
 }

--- a/src/main/java/com/praise/push/adapter/in/web/KeywordController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/KeywordController.java
@@ -23,7 +23,7 @@ class KeywordController {
      * get recommendation keywords as many as size
      */
     @GetMapping("/keywords/recommendation")
-    public ResponseEntity<List<Keyword>> recommendationKeywords(@RequestParam Integer size) {
+    ResponseEntity<List<Keyword>> recommendationKeywords(@RequestParam Integer size) {
         return ResponseDto.ok(keywordUseCase.getRandomRecommendationKeywords(size));
     }
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentJpaEntity.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentJpaEntity.java
@@ -38,7 +38,7 @@ class CommentJpaEntity extends BaseTimeEntity {
     /**
      * related post
      */
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @ManyToOne(optional = false)
     @JoinColumn(name = "post_id")
     private PostJpaEntity post;
 

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentMapper.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentMapper.java
@@ -1,0 +1,32 @@
+package com.praise.push.adapter.out.persistence;
+
+import com.praise.push.domain.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+class CommentMapper {
+
+    private final PostMapper postMapper;
+
+    CommentJpaEntity mapToEntity(Comment comment) {
+        return CommentJpaEntity.builder()
+                .id(comment.getId())
+                .nickname(comment.getNickname())
+                .content(comment.getContent())
+                .imageUrl(comment.getImageUrl())
+                .post(postMapper.mapToEntity(comment.getPost()))
+                .build();
+    }
+
+    Comment mapToModel(CommentJpaEntity entity) {
+        return Comment.builder()
+                .id(entity.getId())
+                .nickname(entity.getNickname())
+                .content(entity.getContent())
+                .imageUrl(entity.getImageUrl())
+                .post(postMapper.mapToModel(entity.getPost()))
+                .build();
+    }
+}

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -1,0 +1,20 @@
+package com.praise.push.adapter.out.persistence;
+
+import com.praise.push.application.port.out.LoadCommentPort;
+import com.praise.push.application.port.out.RecordCommentPort;
+import com.praise.push.domain.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
+
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+
+    @Override
+    public void createComment(Comment comment) {
+        commentRepository.save(commentMapper.mapToEntity(comment));
+    }
+}

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -3,7 +3,10 @@ package com.praise.push.adapter.out.persistence;
 import com.praise.push.application.port.out.LoadCommentPort;
 import com.praise.push.application.port.out.RecordCommentPort;
 import com.praise.push.domain.Comment;
+import com.praise.push.domain.Post;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -12,6 +15,7 @@ class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
 
     private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
+    private final PostMapper postMapper;
 
     /**
      * persist comment entity
@@ -27,5 +31,13 @@ class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
     @Override
     public void deleteComment(Long commendId) {
         commentRepository.deleteById(commendId);
+    }
+
+    @Override
+    public Page<Comment> loadComments(Post post, Pageable pageable) {
+        Page<CommentJpaEntity> comments = commentRepository
+                .findAllByPostOrderByIdDesc(postMapper.mapToEntity(post), pageable);
+
+        return comments.map(commentMapper::mapToModel);
     }
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -13,8 +13,19 @@ class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
     private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
 
+    /**
+     * persist comment entity
+     */
     @Override
     public void createComment(Comment comment) {
         commentRepository.save(commentMapper.mapToEntity(comment));
+    }
+
+    /**
+     * If comment exist, delete it. ignore it if dosen't exist.
+     */
+    @Override
+    public void deleteComment(Long commendId) {
+        commentRepository.deleteById(commendId);
     }
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -34,6 +34,15 @@ class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
     }
 
     @Override
+    public Comment loadComment(Long commentId) {
+        CommentJpaEntity comment = commentRepository.findById(commentId)
+                // TODO: replace custom exception
+                .orElseThrow(() -> new RuntimeException("Not Found Resource"));
+
+        return commentMapper.mapToModel(comment);
+    }
+
+    @Override
     public Page<Comment> loadComments(Post post, Pageable pageable) {
         Page<CommentJpaEntity> comments = commentRepository
                 .findAllByPostOrderByIdDesc(postMapper.mapToEntity(post), pageable);

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
@@ -1,6 +1,10 @@
 package com.praise.push.adapter.out.persistence;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 interface CommentRepository extends JpaRepository<CommentJpaEntity, Long> {
+
+    Page<CommentJpaEntity> findAllByPostOrderByIdDesc(PostJpaEntity post, Pageable pageable);
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
@@ -1,0 +1,6 @@
+package com.praise.push.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface CommentRepository extends JpaRepository<CommentJpaEntity, Long> {
+}

--- a/src/main/java/com/praise/push/adapter/out/persistence/PostMapper.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/PostMapper.java
@@ -11,6 +11,7 @@ class PostMapper {
 
     PostJpaEntity mapToEntity(Post post) {
         return PostJpaEntity.builder()
+                .id(post.getId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
@@ -21,6 +22,7 @@ class PostMapper {
 
     Post mapToModel(PostJpaEntity jpaEntity) {
         return Post.builder()
+                .id(jpaEntity.getId())
                 .title(jpaEntity.getTitle())
                 .content(jpaEntity.getContent())
                 .imageUrl(jpaEntity.getImageUrl())

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -19,7 +19,6 @@ public class CommentService implements CommentUseCase {
     private final LoadCommentPort loadCommentPort;
     private final RecordCommentPort recordCommentPort;
 
-    @Transactional
     @Override
     public void createComment(CreateCommentCommand command, Long postId) {
         Post post = loadPostPort.findPost(postId);
@@ -31,5 +30,10 @@ public class CommentService implements CommentUseCase {
                 .post(post)
                 .build();
         recordCommentPort.createComment(comment);
+    }
+
+    @Override
+    public void deleteComment(Long commentId) {
+        recordCommentPort.deleteComment(commentId);
     }
 }

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -26,7 +26,6 @@ public class CommentService implements CommentUseCase {
     @Override
     public void createComment(CreateCommentCommand command, Long postId) {
         Post post = loadPostPort.findPost(postId);
-        System.out.println(post.getKeyword().getKeyword());
         Comment comment = Comment.builder()
                 .nickname(command.getNickname())
                 .content(command.getContent())

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -2,14 +2,17 @@ package com.praise.push.application;
 
 import com.praise.push.application.port.in.CommentUseCase;
 import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.application.port.out.LoadCommentPort;
 import com.praise.push.application.port.out.LoadPostPort;
 import com.praise.push.application.port.out.RecordCommentPort;
 import com.praise.push.domain.Comment;
 import com.praise.push.domain.Post;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -35,5 +38,14 @@ public class CommentService implements CommentUseCase {
     @Override
     public void deleteComment(Long commentId) {
         recordCommentPort.deleteComment(commentId);
+    }
+
+    @Override
+    public Page<CommentSimpleResponseDto> getComments(Long postId, Integer page, Integer size) {
+        Post post = loadPostPort.findPost(postId);
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Comment> comments = loadCommentPort.loadComments(post, pageable);
+
+        return comments.map(CommentSimpleResponseDto::fromModel);
     }
 }

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -1,0 +1,35 @@
+package com.praise.push.application;
+
+import com.praise.push.application.port.in.CommentUseCase;
+import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.application.port.out.LoadCommentPort;
+import com.praise.push.application.port.out.LoadPostPort;
+import com.praise.push.application.port.out.RecordCommentPort;
+import com.praise.push.domain.Comment;
+import com.praise.push.domain.Post;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService implements CommentUseCase {
+
+    private final LoadPostPort loadPostPort;
+    private final LoadCommentPort loadCommentPort;
+    private final RecordCommentPort recordCommentPort;
+
+    @Transactional
+    @Override
+    public void createComment(CreateCommentCommand command, Long postId) {
+        Post post = loadPostPort.findPost(postId);
+        System.out.println(post.getKeyword().getKeyword());
+        Comment comment = Comment.builder()
+                .nickname(command.getNickname())
+                .content(command.getContent())
+                .imageUrl("imageUrl") // TODO: replace uploaded image url
+                .post(post)
+                .build();
+        recordCommentPort.createComment(comment);
+    }
+}

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -2,6 +2,7 @@ package com.praise.push.application;
 
 import com.praise.push.application.port.in.CommentUseCase;
 import com.praise.push.application.port.in.CreateCommentCommand;
+import com.praise.push.application.port.in.dto.CommentDetailResponseDto;
 import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.application.port.out.LoadCommentPort;
 import com.praise.push.application.port.out.LoadPostPort;
@@ -38,6 +39,13 @@ public class CommentService implements CommentUseCase {
     @Override
     public void deleteComment(Long commentId) {
         recordCommentPort.deleteComment(commentId);
+    }
+
+    @Override
+    public CommentDetailResponseDto getComment(Long commentId) {
+        Comment comment = loadCommentPort.loadComment(commentId);
+
+        return CommentDetailResponseDto.fromModel(comment);
     }
 
     @Override

--- a/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
+++ b/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
@@ -1,0 +1,5 @@
+package com.praise.push.application.port.in;
+
+public interface CommentUseCase {
+    void createComment(CreateCommentCommand command, Long postId);
+}

--- a/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
+++ b/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
@@ -1,10 +1,12 @@
 package com.praise.push.application.port.in;
 
+import com.praise.push.application.port.in.dto.CommentDetailResponseDto;
 import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import org.springframework.data.domain.Page;
 
 public interface CommentUseCase {
     void createComment(CreateCommentCommand command, Long postId);
     void deleteComment(Long commentId);
+    CommentDetailResponseDto getComment(Long commentId);
     Page<CommentSimpleResponseDto> getComments(Long postId, Integer page, Integer size);
 }

--- a/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
+++ b/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
@@ -1,6 +1,10 @@
 package com.praise.push.application.port.in;
 
+import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
+import org.springframework.data.domain.Page;
+
 public interface CommentUseCase {
     void createComment(CreateCommentCommand command, Long postId);
     void deleteComment(Long commentId);
+    Page<CommentSimpleResponseDto> getComments(Long postId, Integer page, Integer size);
 }

--- a/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
+++ b/src/main/java/com/praise/push/application/port/in/CommentUseCase.java
@@ -2,4 +2,5 @@ package com.praise.push.application.port.in;
 
 public interface CommentUseCase {
     void createComment(CreateCommentCommand command, Long postId);
+    void deleteComment(Long commentId);
 }

--- a/src/main/java/com/praise/push/application/port/in/CreateCommentCommand.java
+++ b/src/main/java/com/praise/push/application/port/in/CreateCommentCommand.java
@@ -1,0 +1,13 @@
+package com.praise.push.application.port.in;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateCommentCommand {
+    private String nickname;
+    private String content;
+}

--- a/src/main/java/com/praise/push/application/port/in/dto/CommentDetailResponseDto.java
+++ b/src/main/java/com/praise/push/application/port/in/dto/CommentDetailResponseDto.java
@@ -1,0 +1,21 @@
+package com.praise.push.application.port.in.dto;
+
+import com.praise.push.domain.Comment;
+import lombok.Builder;
+
+@Builder
+public record CommentDetailResponseDto(
+        Long commentId,
+        String nickname,
+        String content,
+        String imageUrl
+) {
+    public static CommentDetailResponseDto fromModel(Comment comment) {
+        return CommentDetailResponseDto.builder()
+                .commentId(comment.getId())
+                .nickname(comment.getNickname())
+                .content(comment.getContent())
+                .imageUrl(comment.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/praise/push/application/port/in/dto/CommentSimpleResponseDto.java
+++ b/src/main/java/com/praise/push/application/port/in/dto/CommentSimpleResponseDto.java
@@ -1,0 +1,17 @@
+package com.praise.push.application.port.in.dto;
+
+import com.praise.push.domain.Comment;
+import lombok.Builder;
+
+@Builder
+public record CommentSimpleResponseDto(
+        Long commentId,
+        String nickname
+) {
+    public static CommentSimpleResponseDto fromModel(Comment comment) {
+        return CommentSimpleResponseDto.builder()
+                .commentId(comment.getId())
+                .nickname(comment.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
@@ -1,0 +1,4 @@
+package com.praise.push.application.port.out;
+
+public interface LoadCommentPort {
+}

--- a/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
@@ -6,5 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface LoadCommentPort {
+    Comment loadComment(Long commentId);
     Page<Comment> loadComments(Post post, Pageable pageable);
 }

--- a/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/LoadCommentPort.java
@@ -1,4 +1,10 @@
 package com.praise.push.application.port.out;
 
+import com.praise.push.domain.Comment;
+import com.praise.push.domain.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 public interface LoadCommentPort {
+    Page<Comment> loadComments(Post post, Pageable pageable);
 }

--- a/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
@@ -1,0 +1,7 @@
+package com.praise.push.application.port.out;
+
+import com.praise.push.domain.Comment;
+
+public interface RecordCommentPort {
+    void createComment(Comment comment);
+}

--- a/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
@@ -4,4 +4,5 @@ import com.praise.push.domain.Comment;
 
 public interface RecordCommentPort {
     void createComment(Comment comment);
+    void deleteComment(Long commentId);
 }


### PR DESCRIPTION
- Resolved: #43 

<br>

### Process
1. 칭찬 응답 생성 (이미지 업로드 기능 추가 시 추후 적용) ✅
2. 칭찬 응답 삭제 (작성자만 삭제 가능하도록 -> 추후 인증/인가 추가 시 적용) ✅
3. 칭찬 응답 페이지 조회 ✅
4. 칭찬 응답 단건 조회 ✅

    - 도메인 객체(Comment)와 엔티티 객체(CommentJpaEntity) 사이에 매핑을 하는 CommentMapper에 의해서 JPA의 Lazy Loading이 의미가 없어진다. 이 부분에 대해서 좀 더 찾아보고, 해결 방안을 고안해보려고 한다. (아래 고민중인 내용 정리)

<br>

## 관련 내용 정리
JPA Entity 객체와 Domain POJO 객체를 따로 사용하려고 했을 때, 둘 사이를 변환해주는 Mapper가 필요.

여기서 JPA Lazy Loading을 사용할 수 있을까?

### Comment POJO 객체

```java
package com.praise.push.domain;

import lombok.AllArgsConstructor;
import lombok.Builder;
import lombok.Getter;
import lombok.NoArgsConstructor;

@Builder
@NoArgsConstructor
@AllArgsConstructor
@Getter
public class Comment {
    private Long id;
    private String nickname;
    private String content;
    private String imageUrl;
    private Post post;
}
```

### Comment Jpa Entity 객체

```java
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Entity(name = "comments")
class CommentJpaEntity extends BaseTimeEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    @Column(name = "comment_id")
    private Long id;
    private String nickname;
    private String content;
    private String imageUrl;
    
    @ManyToOne(fetch = FetchType.LAZY, optional = false)
    @JoinColumn(name = "post_id")
    private PostJpaEntity post;

    @Builder
    public CommentJpaEntity(Long id, String nickname, String content, String imageUrl, PostJpaEntity post) {
        this.id = id;
        this.nickname = nickname;
        this.content = content;
        this.imageUrl = imageUrl;
        this.post = post;
    }
}
```

### Entity ↔ Domain 객체 변환 Mapper

```java
@RequiredArgsConstructor
@Component
class CommentMapper {

    private final PostMapper postMapper;

    CommentJpaEntity mapToEntity(Comment comment) {
        return CommentJpaEntity.builder()
                .id(comment.getId())
                .nickname(comment.getNickname())
                .content(comment.getContent())
                .imageUrl(comment.getImageUrl())
                .post(postMapper.mapToEntity(comment.getPost()))
                .build();
    }

    Comment mapToModel(CommentJpaEntity entity) {
        return Comment.builder()
                .id(entity.getId())
                .nickname(entity.getNickname())
                .content(entity.getContent())
                .imageUrl(entity.getImageUrl())
                .post(postMapper.mapToModel(entity.getPost()))
                .build();
    }
}
```

여기서 Mapper의 mapToModel()을 보면 Jpa Entity 객체를 파라미터로 받아서 Comment 도메인 객체로 바꿔준다.

```java
@ManyToOne(fetch = FetchType.LAZY, optional = false)
@JoinColumn(name = "post_id")
private PostJpaEntity post;
```

CommentJpaEntity를 보면 post에는 LAZY가 적용되어 있다.

즉, comment를 조회할 때, post는 필요한 로직에서만 getter를 통해 가져올 수 있다.

하지만, mapToModel()에서 무조건 entity.getPost()를 통해서 Domain 객체를 채워서 반환한다.

즉 Lazy Loading은 사용하고자 적용했지만 Comment를 조회할 때는 필연적으로 Eager과 같이 동작한다.

완벽한 POJO의 도메인 객체를 사용하고자할 때, JPA의 Lazy Loading 기능을 사용할 수 있을까?

### Lazy에서의 Comment 단건 조회 시

```java
Hibernate: 
    select
        c1_0.comment_id,
        c1_0.content,
        c1_0.created_date,
        c1_0.image_url,
        c1_0.modified_date,
        c1_0.nickname,
        c1_0.post_id 
    from
        comments c1_0 
    where
        c1_0.comment_id=?
Hibernate: 
    select
        p1_0.post_id,
        p1_0.content,
        p1_0.created_date,
        p1_0.image_url,
        k1_0.keyword_id,
        k1_0.created_date,
        k1_0.keyword,
        k1_0.modified_date,
        p1_0.modified_date,
        p1_0.title,
        p1_0.visible 
    from
        posts p1_0 
    left join
        keywords k1_0 
            on k1_0.keyword_id=p1_0.keyword_id 
    where
        p1_0.post_id=?
```

Lazy 로딩 때문에 mapToModel()을 쓰면 select 쿼리가 2번씩 나가게 된다.

post를  가져오면서 post와 연관된 keyword까지 잔뜩 들고온다. (keyword는 현재 Eager로 되어 있음)

### Eager에서의 Comment 단건 조회 시

```java
Hibernate: 
    select
        c1_0.comment_id,
        c1_0.content,
        c1_0.created_date,
        c1_0.image_url,
        c1_0.modified_date,
        c1_0.nickname,
        c1_0.post_id,
        p1_0.post_id,
        p1_0.content,
        p1_0.created_date,
        p1_0.image_url,
        k1_0.keyword_id,
        k1_0.created_date,
        k1_0.keyword,
        k1_0.modified_date,
        p1_0.modified_date,
        p1_0.title,
        p1_0.visible 
    from
        comments c1_0 
    join
        posts p1_0 
            on p1_0.post_id=c1_0.post_id 
    left join
        keywords k1_0 
            on k1_0.keyword_id=p1_0.keyword_id 
    where
        c1_0.comment_id=?
```

left join으로 한번의 쿼리로 가져오게 된다.

결국 사용되지 않는 post의 정보까지 다 가져오게 된다.

현재는 Eager로 그냥 적용해둔 상태이다. (방법을 찾을 때 까지...🤓)
> 같은 데이터를 가져오는데, 2번의 쿼리로 나뉘어서 가져오는 것보다는 한 번의 쿼리로 가져오는 것이 낫다고 판단.

<br>

## 결론
- 최종적으로는 위 쿼리에서 사용되는 것이 comment와 관련된 부분 밖에 없기 때문에 Comment의 Post는 Lazy 로딩으로 가져와야 하고, 이를 CommentMapper에서 변경하는 단계에서 어떻게 적용할 수 있을지 고민중입니다.