### PR TITLE
image upload interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
     implementation 'net.gpedro.integrations.slack:slack-webhook:1.4.0'
     implementation 'mysql:mysql-connector-java:8.0.33'
+    implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.529')
+    implementation 'com.amazonaws:aws-java-sdk-s3'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/praise/push/adapter/in/web/PostController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/PostController.java
@@ -9,13 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/praise-push/api/v1")
+@RequestMapping("/praise-up/api/v1")
 @RequiredArgsConstructor
 class PostController {
     private final PostUseCase postUseCase;
 
     @PostMapping
-    void createPost(@RequestBody CreatePostCommand command) {
+    void createPost(@ModelAttribute CreatePostCommand command) {
         postUseCase.createPost(command);
     }
 

--- a/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 
 @RequiredArgsConstructor
 @Component
-public class ImagePersistenceAdapter implements RecordImagePort {
+class ImagePersistenceAdapter implements RecordImagePort {
     @Value("${cloud.naver.credentials.bucket}")
     private String bucket;
 
@@ -46,7 +46,7 @@ public class ImagePersistenceAdapter implements RecordImagePort {
                     .withCannedAcl(CannedAccessControlList.PublicRead));
 
             // s3에 업로드한 폴더 및 파일 URL
-            uploadFileUrl = endPoint + bucket + "/" + fileName;
+            uploadFileUrl = endPoint + "/" + bucket + "/" + fileName;
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -55,7 +55,7 @@ public class ImagePersistenceAdapter implements RecordImagePort {
     }
 
     private void validateFileSize(long size) {
-        if (size >= MAX_FILE_SIZE) {
+        if (size > MAX_FILE_SIZE) {
             throw new RuntimeException("File size is over 1MB");
         }
     }

--- a/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
@@ -48,7 +48,7 @@ class ImagePersistenceAdapter implements RecordImagePort {
             // s3에 업로드한 폴더 및 파일 URL
             uploadFileUrl = endPoint + "/" + bucket + "/" + fileName;
         } catch (IOException e) {
-            e.printStackTrace();
+            // TODO: custom exception 추가
         }
 
         return uploadFileUrl;

--- a/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/ImagePersistenceAdapter.java
@@ -1,0 +1,66 @@
+package com.praise.push.adapter.out.persistence;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.praise.push.application.port.out.RecordImagePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class ImagePersistenceAdapter implements RecordImagePort {
+    @Value("${cloud.naver.credentials.bucket}")
+    private String bucket;
+
+    @Value("${cloud.naver.credentials.end-point}")
+    private String endPoint;
+
+    private final AmazonS3 objectStorage;
+
+    @Override
+    public String uploadImage(MultipartFile file) {
+        String fileName = createFileName(file.getOriginalFilename());
+        String uploadFileUrl = "";
+
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try (InputStream inputStream = file.getInputStream()){
+
+
+            // object storage 폴더 및 파일 업로드
+            objectStorage.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+
+            // s3에 업로드한 폴더 및 파일 URL
+            uploadFileUrl = endPoint + bucket + "/" + fileName;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return uploadFileUrl;
+    }
+
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 형식의 파일(" + fileName + ") 입니다.");
+        }
+    }
+}

--- a/src/main/java/com/praise/push/application/PostService.java
+++ b/src/main/java/com/praise/push/application/PostService.java
@@ -4,6 +4,7 @@ import com.praise.push.application.port.in.CreatePostCommand;
 import com.praise.push.application.port.in.PostUseCase;
 import com.praise.push.application.port.in.UpdatePostCommand;
 import com.praise.push.application.port.out.LoadPostPort;
+import com.praise.push.application.port.out.RecordImagePort;
 import com.praise.push.application.port.out.RecordPostPort;
 import com.praise.push.domain.Keyword;
 import com.praise.push.domain.Post;
@@ -16,14 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class PostService implements PostUseCase {
     private final RecordPostPort recordPostPort;
+    private final RecordImagePort recordImagePort;
     private final LoadPostPort loadPostPort;
 
     @Override
     public boolean createPost(CreatePostCommand command) {
+        String imageUrl = recordImagePort.uploadImage(command.getImage());
+
         Post post = Post.builder()
                 .title(command.getTitle())
                 .content(command.getContent())
-                .imageUrl(command.getImageUrl())
+                .imageUrl(imageUrl)
                 .keyword(Keyword.builder().keyword(command.getKeyword()).build())
                 .visible(false)
                 .build();

--- a/src/main/java/com/praise/push/application/port/in/CreatePostCommand.java
+++ b/src/main/java/com/praise/push/application/port/in/CreatePostCommand.java
@@ -3,13 +3,16 @@ package com.praise.push.application.port.in;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class CreatePostCommand {
     private String title;
     private String content;
-    private String imageUrl;
+    private MultipartFile image;
     private String keyword;
 }

--- a/src/main/java/com/praise/push/application/port/out/RecordImagePort.java
+++ b/src/main/java/com/praise/push/application/port/out/RecordImagePort.java
@@ -1,0 +1,7 @@
+package com.praise.push.application.port.out;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface RecordImagePort {
+    String uploadImage(MultipartFile file);
+}

--- a/src/main/java/com/praise/push/config/ObjectStorageConfig.java
+++ b/src/main/java/com/praise/push/config/ObjectStorageConfig.java
@@ -1,0 +1,38 @@
+package com.praise.push.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectStorageConfig {
+    @Value("${cloud.naver.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.naver.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.naver.credentials.region}")
+    private String region;
+
+    @Value("${cloud.naver.credentials.bucket}")
+    private String bucket;
+
+    @Value("${cloud.naver.credentials.end-point}")
+    private String endPoint;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endPoint, region))
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: none
-
 error:
   webhook:
     url: ${DEV_WEBHOOK_URL}
+cloud:
+  naver:
+    credentials:
+      end-point: "https://kr.object.ncloudstorage.com"
+      region: "kr-standard"
+      access-key: ${OBJECT_STORAGE_ACCESS_KEY}
+      secret-key: ${OBJECT_STORAGE_SECRET_KEY}
+      bucket: "praise-up-image"


### PR DESCRIPTION
# image upload 인터페이스 추가 
- Resolve: #38 

## 작업 내역
- object storage를 사용하여 image upload를 하였습니다.

## 공유할 내용
**printStackTrace를 지양해야 하는 이유**
훈섭님의 리뷰를 반영하면서 Throwable.printStackTrace()에 대해서 찾아보았습니다. 
다음과 같은 이유로 사용을 지양해야 한다고 하네요. 
1. 오류 출력이 실제로 어디로 가는지 알 수 없다.
2. 많은 오버헤드 발생
3. 보존 정책 설정 불가
4. 보안성이 떨어짐
상세한 내용은 [블로그](https://velog.io/@choiys0212/Throwable.printStackTrace%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EB%A9%B4-%EC%95%88%EB%90%98%EB%8A%94-%EC%9D%B4%EC%9C%A0)를 참고하시면 좋을 것 같습니다.

👀 살펴보던 중에 아직 저희는 logging에 관한 내용이 논의되지 않았더라구요. 기능 구현과 별개이지만 추후에 함께 이야기해보면 좋을 것 같습니다~

**Exception 패키지 추가**
자바 자체에서 제공하는 exception을 사용하였는데 1) 직관적인 이름, 2) 추후 테스트를 위해서 Exception 패키지를 추가하여 관리하는 것이 좋지 않을까 싶습니다.

상황에 맞게 적절하게 사용하는 것이 좋지만, 개인적으로 [이 글](https://tecoble.techcourse.co.kr/post/2020-08-17-custom-exception/)에서 **4. 예외 발생 후 처리가 용이하다.** 라는 부분에서 custom exception 사용에 끌리는군요~

작업하고 있는 이슈입니다.
https://github.com/depromeet/praise-push-server/issues/54

## 추가 작업 내역
- [ ] 정적 변수 enum으로 변경
- [ ] custom exception 처리

## 참고