### PR TITLE
Add image upload to comments and Modify Post Logic

### DIFF
--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -29,14 +29,14 @@ class CommentController {
     }
 
     @GetMapping("/comments/{commentId}")
-    ResponseEntity<?> getComments(@PathVariable Long commentId) {
+    ResponseEntity<?> getComments(@PathVariable("commentId") Long commentId) {
         CommentDetailResponseDto comment = commentUseCase.getComment(commentId);
 
         return ResponseDto.ok(comment);
     }
 
     @DeleteMapping("/comments/{commentId}")
-    ResponseEntity<Void> deleteComment(@PathVariable Long commentId) {
+    ResponseEntity<Void> deleteComment(@PathVariable("commentId") Long commentId) {
         commentUseCase.deleteComment(commentId);
 
         return ResponseDto.noContent();
@@ -44,7 +44,7 @@ class CommentController {
 
     @GetMapping("/posts/{postId}/comments")
     ResponseEntity<Page<CommentSimpleResponseDto>> getComments(
-        @PathVariable Long postId,
+        @PathVariable("postId") Long postId,
         @RequestParam(value = "page", defaultValue = "0") Integer page,
         @RequestParam(value = "size", defaultValue = "24") Integer size
     ) {

--- a/src/main/java/com/praise/push/adapter/in/web/CommentController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/CommentController.java
@@ -7,6 +7,7 @@ import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.common.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,11 +18,10 @@ class CommentController {
 
     private final CommentUseCase commentUseCase;
 
-    @PostMapping("/posts/{postId}/comments")
+    @PostMapping(value = "/posts/{postId}/comments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<Void> createComment(
-        // TODO: uploaded image file
-        @RequestBody CreateCommentCommand command,
-        @PathVariable Long postId
+        @ModelAttribute CreateCommentCommand command,
+        @PathVariable("postId") Long postId
     ) {
         commentUseCase.createComment(command, postId);
 

--- a/src/main/java/com/praise/push/adapter/in/web/KeywordController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/KeywordController.java
@@ -23,7 +23,7 @@ class KeywordController {
      * get recommendation keywords as many as size
      */
     @GetMapping("/keywords/recommendation")
-    ResponseEntity<List<Keyword>> recommendationKeywords(@RequestParam Integer size) {
+    ResponseEntity<List<Keyword>> recommendationKeywords(@RequestParam("size") Integer size) {
         return ResponseDto.ok(keywordUseCase.getRandomRecommendationKeywords(size));
     }
 }

--- a/src/main/java/com/praise/push/adapter/in/web/PostController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/PostController.java
@@ -6,6 +6,7 @@ import com.praise.push.application.port.in.UpdatePostCommand;
 import com.praise.push.application.port.out.PostResponse;
 import com.praise.push.domain.Post;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,12 +15,12 @@ import org.springframework.web.bind.annotation.*;
 class PostController {
     private final PostUseCase postUseCase;
 
-    @PostMapping
+    @PostMapping(value = "/posts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     void createPost(@ModelAttribute CreatePostCommand command) {
         postUseCase.createPost(command);
     }
 
-    @GetMapping
+    @GetMapping("/posts/{postId}")
     PostResponse findPost(@PathVariable(name = "postId") Long postId) {
         Post post = postUseCase.findPost(postId);
         return PostResponse.builder()
@@ -31,12 +32,12 @@ class PostController {
                 .build();
     }
 
-    @DeleteMapping
+    @DeleteMapping("/posts/{postId}")
     void deletePost(@PathVariable(name = "postId") Long postId) {
         postUseCase.deletePost(postId);
     }
 
-    @PatchMapping
+    @PatchMapping("/posts/{postId}")
     PostResponse updatePost(@PathVariable(name = "postId") Long postId,
                             @RequestBody UpdatePostCommand command) {
         postUseCase.updatePost(postId, command);

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentPersistenceAdapter.java
@@ -34,6 +34,11 @@ class CommentPersistenceAdapter implements LoadCommentPort, RecordCommentPort {
     }
 
     @Override
+    public void deleteCommentsByPostId(Long postId) {
+        commentRepository.deleteByPostId(postId);
+    }
+
+    @Override
     public Comment loadComment(Long commentId) {
         CommentJpaEntity comment = commentRepository.findById(commentId)
                 // TODO: replace custom exception

--- a/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/CommentRepository.java
@@ -3,8 +3,15 @@ package com.praise.push.adapter.out.persistence;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 interface CommentRepository extends JpaRepository<CommentJpaEntity, Long> {
 
     Page<CommentJpaEntity> findAllByPostOrderByIdDesc(PostJpaEntity post, Pageable pageable);
+
+    @Modifying
+    @Query(value = "delete from comments c where c.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/KeywordJpaEntity.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/KeywordJpaEntity.java
@@ -29,6 +29,6 @@ class KeywordJpaEntity extends BaseTimeEntity {
     /**
      * 게시글
      */
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "keyword", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "keyword")
     private List<PostJpaEntity> posts;
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/KeywordMapper.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/KeywordMapper.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 class KeywordMapper {
     KeywordJpaEntity mapToEntity(Keyword keyword) {
         return KeywordJpaEntity.builder()
+                .id(keyword.getId())
                 .keyword(keyword.getKeyword())
                 .build();
     }

--- a/src/main/java/com/praise/push/adapter/out/persistence/KeywordPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/KeywordPersistenceAdapter.java
@@ -20,4 +20,12 @@ class KeywordPersistenceAdapter implements LoadKeywordPort {
         return keywordRepository.findAll()
                 .stream().map(keywordMapper::mapToModel).collect(Collectors.toList());
     }
+
+    @Override
+    public Keyword loadKeywordById(Long keywordId) {
+        KeywordJpaEntity keyword = keywordRepository.findById(keywordId)
+                .orElseThrow(() -> new RuntimeException("Not Exist"));
+
+        return keywordMapper.mapToModel(keyword);
+    }
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/PostJpaEntity.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/PostJpaEntity.java
@@ -40,7 +40,7 @@ class PostJpaEntity extends BaseTimeEntity {
     /**
      * 키워드
      */
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne()
     @JoinColumn(name = "keyword_id")
     private KeywordJpaEntity keyword;
 

--- a/src/main/java/com/praise/push/application/CommentService.java
+++ b/src/main/java/com/praise/push/application/CommentService.java
@@ -7,6 +7,7 @@ import com.praise.push.application.port.in.dto.CommentSimpleResponseDto;
 import com.praise.push.application.port.out.LoadCommentPort;
 import com.praise.push.application.port.out.LoadPostPort;
 import com.praise.push.application.port.out.RecordCommentPort;
+import com.praise.push.application.port.out.RecordImagePort;
 import com.praise.push.domain.Comment;
 import com.praise.push.domain.Post;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +23,16 @@ public class CommentService implements CommentUseCase {
     private final LoadPostPort loadPostPort;
     private final LoadCommentPort loadCommentPort;
     private final RecordCommentPort recordCommentPort;
+    private final RecordImagePort recordImagePort;
 
     @Override
     public void createComment(CreateCommentCommand command, Long postId) {
         Post post = loadPostPort.findPost(postId);
+        String imageUrl = recordImagePort.uploadImage(command.getImage());
         Comment comment = Comment.builder()
                 .nickname(command.getNickname())
                 .content(command.getContent())
-                .imageUrl("imageUrl") // TODO: replace uploaded image url
+                .imageUrl(imageUrl)
                 .post(post)
                 .build();
         recordCommentPort.createComment(comment);

--- a/src/main/java/com/praise/push/application/PostService.java
+++ b/src/main/java/com/praise/push/application/PostService.java
@@ -3,6 +3,7 @@ package com.praise.push.application;
 import com.praise.push.application.port.in.CreatePostCommand;
 import com.praise.push.application.port.in.PostUseCase;
 import com.praise.push.application.port.in.UpdatePostCommand;
+import com.praise.push.application.port.out.LoadKeywordPort;
 import com.praise.push.application.port.out.LoadPostPort;
 import com.praise.push.application.port.out.RecordImagePort;
 import com.praise.push.application.port.out.RecordPostPort;
@@ -19,16 +20,18 @@ public class PostService implements PostUseCase {
     private final RecordPostPort recordPostPort;
     private final RecordImagePort recordImagePort;
     private final LoadPostPort loadPostPort;
+    private final LoadKeywordPort keywordPort;
 
     @Override
     public boolean createPost(CreatePostCommand command) {
         String imageUrl = recordImagePort.uploadImage(command.getImage());
+        Keyword keyword = keywordPort.loadKeywordById(command.getKeywordId());
 
         Post post = Post.builder()
                 .title(command.getTitle())
                 .content(command.getContent())
                 .imageUrl(imageUrl)
-                .keyword(Keyword.builder().keyword(command.getKeyword()).build())
+                .keyword(keyword)
                 .visible(false)
                 .build();
 

--- a/src/main/java/com/praise/push/application/PostService.java
+++ b/src/main/java/com/praise/push/application/PostService.java
@@ -3,10 +3,7 @@ package com.praise.push.application;
 import com.praise.push.application.port.in.CreatePostCommand;
 import com.praise.push.application.port.in.PostUseCase;
 import com.praise.push.application.port.in.UpdatePostCommand;
-import com.praise.push.application.port.out.LoadKeywordPort;
-import com.praise.push.application.port.out.LoadPostPort;
-import com.praise.push.application.port.out.RecordImagePort;
-import com.praise.push.application.port.out.RecordPostPort;
+import com.praise.push.application.port.out.*;
 import com.praise.push.domain.Keyword;
 import com.praise.push.domain.Post;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +18,7 @@ public class PostService implements PostUseCase {
     private final RecordImagePort recordImagePort;
     private final LoadPostPort loadPostPort;
     private final LoadKeywordPort keywordPort;
+    private final RecordCommentPort recordCommentPort;
 
     @Override
     public boolean createPost(CreatePostCommand command) {
@@ -44,8 +42,10 @@ public class PostService implements PostUseCase {
         return loadPostPort.findPost(postId);
     }
 
+    @Transactional
     @Override
     public boolean deletePost(Long postId) {
+        recordCommentPort.deleteCommentsByPostId(postId);
         recordPostPort.deletePost(postId);
         return true;
     }

--- a/src/main/java/com/praise/push/application/port/in/CreateCommentCommand.java
+++ b/src/main/java/com/praise/push/application/port/in/CreateCommentCommand.java
@@ -3,11 +3,15 @@ package com.praise.push.application.port.in;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateCommentCommand {
     private String nickname;
     private String content;
+    private MultipartFile image;
 }

--- a/src/main/java/com/praise/push/application/port/in/CreatePostCommand.java
+++ b/src/main/java/com/praise/push/application/port/in/CreatePostCommand.java
@@ -14,5 +14,5 @@ public class CreatePostCommand {
     private String title;
     private String content;
     private MultipartFile image;
-    private String keyword;
+    private Long keywordId;
 }

--- a/src/main/java/com/praise/push/application/port/out/LoadKeywordPort.java
+++ b/src/main/java/com/praise/push/application/port/out/LoadKeywordPort.java
@@ -3,10 +3,16 @@ package com.praise.push.application.port.out;
 import com.praise.push.domain.Keyword;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LoadKeywordPort {
     /**
      * returns all keywords
      */
     List<Keyword> loadKeywords();
+
+    /**
+     * returns keyword with matching id
+     */
+    Keyword loadKeywordById(Long keywordId);
 }

--- a/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
+++ b/src/main/java/com/praise/push/application/port/out/RecordCommentPort.java
@@ -5,4 +5,5 @@ import com.praise.push.domain.Comment;
 public interface RecordCommentPort {
     void createComment(Comment comment);
     void deleteComment(Long commentId);
+    void deleteCommentsByPostId(Long postId);
 }


### PR DESCRIPTION
- Resolved: #58 
- Resolved: #59 

<br>

## ✋🏻 이런 부분을 적용했습니다.
1. 칭찬 반응에 이미지 업로드 기능을 추가했습니다.
    - 관련된 PR : #47  

<br>    

2. Swagger에서 Path Variable과 Request Parameter가 명시적으로 설정 되도록 name 값을 추가했습니다.
    <img width="400" alt="image" src="https://github.com/depromeet/praise-push-server/assets/70641477/bae457b9-1e78-4fd9-b6eb-060fe6f6b776"> 

<br>

3. 게시글 생성 시 계속해서 생성되는 키워드를 기존 데이터를 사용할 수 있도록 변경해봤습니다.