### PR TITLE
:recycle: refactor: refactoring random keyword recommendation

### DIFF
--- a/src/main/java/com/praise/push/adapter/out/persistence/KeywordPersistenceAdapter.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/KeywordPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.praise.push.adapter.out.persistence;
 
 import com.praise.push.application.port.out.LoadKeywordPort;
+import com.praise.push.application.port.out.RecordKeywordPort;
 import com.praise.push.common.error.exception.PraiseUpException;
 import com.praise.push.common.error.model.ErrorCode;
 import com.praise.push.domain.Keyword;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @Component
-class KeywordPersistenceAdapter implements LoadKeywordPort {
+class KeywordPersistenceAdapter implements LoadKeywordPort, RecordKeywordPort {
 
     private final KeywordRepository keywordRepository;
 
@@ -24,5 +25,10 @@ class KeywordPersistenceAdapter implements LoadKeywordPort {
     public Keyword loadKeywordById(Long keywordId) {
         return keywordRepository.findById(keywordId)
                 .orElseThrow(() -> new PraiseUpException(ErrorCode.NOT_FOUND));
+    }
+
+    @Override
+    public void updateSelectedCount(List<Long> ids) {
+        keywordRepository.updateSelectedCount(ids);
     }
 }

--- a/src/main/java/com/praise/push/adapter/out/persistence/KeywordRepository.java
+++ b/src/main/java/com/praise/push/adapter/out/persistence/KeywordRepository.java
@@ -2,6 +2,15 @@ package com.praise.push.adapter.out.persistence;
 
 import com.praise.push.domain.Keyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+    @Modifying
+    @Query("update Keyword k set k.selectedCount = k.selectedCount + 1 where k.id in (:ids)")
+    void updateSelectedCount(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/praise/push/application/port/out/RecordKeywordPort.java
+++ b/src/main/java/com/praise/push/application/port/out/RecordKeywordPort.java
@@ -1,0 +1,10 @@
+package com.praise.push.application.port.out;
+
+import java.util.List;
+
+public interface RecordKeywordPort {
+    /**
+     * increase selected count of Keywords in ids by 1
+     */
+    void updateSelectedCount(List<Long> ids);
+}

--- a/src/main/java/com/praise/push/application/service/KeywordService.java
+++ b/src/main/java/com/praise/push/application/service/KeywordService.java
@@ -3,31 +3,29 @@ package com.praise.push.application.service;
 import com.praise.push.application.port.in.KeywordUseCase;
 import com.praise.push.application.port.in.dto.KeywordResponseDto;
 import com.praise.push.application.port.out.LoadKeywordPort;
+import com.praise.push.domain.Keyword;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
 public class KeywordService implements KeywordUseCase {
-
     private final LoadKeywordPort loadKeywordPort;
 
     @Override
     @Transactional(readOnly = true)
     public List<KeywordResponseDto> getRandomRecommendationKeywords(Integer size) {
-        List<KeywordResponseDto> keywords = loadKeywordPort.loadKeywords()
-                .stream().map(KeywordResponseDto::fromEntity).collect(Collectors.toList());
+        List<Keyword> keywords = loadKeywordPort.loadKeywords();
 
         if (keywords.size() <= size) {
-            return keywords;
+            return keywords.stream().map(KeywordResponseDto::fromEntity).toList();
         }
-        Collections.shuffle(keywords);
+        keywords.sort((k1, k2) -> k1.getSelectedCount() - k2.getSelectedCount());
+        List<Keyword> recommendationKeywords = keywords.subList(0, size);
 
-        return keywords.subList(0, size);
+        return recommendationKeywords.stream().map(KeywordResponseDto::fromEntity).toList();
     }
 }

--- a/src/main/java/com/praise/push/application/service/KeywordService.java
+++ b/src/main/java/com/praise/push/application/service/KeywordService.java
@@ -3,6 +3,7 @@ package com.praise.push.application.service;
 import com.praise.push.application.port.in.KeywordUseCase;
 import com.praise.push.application.port.in.dto.KeywordResponseDto;
 import com.praise.push.application.port.out.LoadKeywordPort;
+import com.praise.push.application.port.out.RecordKeywordPort;
 import com.praise.push.domain.Keyword;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import java.util.List;
 @Service
 public class KeywordService implements KeywordUseCase {
     private final LoadKeywordPort loadKeywordPort;
+    private final RecordKeywordPort recordKeywordPort;
 
     @Override
     @Transactional(readOnly = true)
@@ -27,5 +29,17 @@ public class KeywordService implements KeywordUseCase {
         List<Keyword> recommendationKeywords = keywords.subList(0, size);
 
         return recommendationKeywords.stream().map(KeywordResponseDto::fromEntity).toList();
+    }
+
+    @Transactional
+    public void updateSelectedCount(Integer size) {
+        List<Keyword> keywords = loadKeywordPort.loadKeywords();
+        keywords.sort((k1, k2) -> k1.getSelectedCount() - k2.getSelectedCount());
+        if (size < keywords.size()) {
+            keywords = keywords.subList(0, size);
+        }
+
+        List<Long> keywordIds = keywords.stream().map(Keyword::getId).toList();
+        recordKeywordPort.updateSelectedCount(keywordIds);
     }
 }

--- a/src/main/java/com/praise/push/batch/cron/post/jobs/KeywordBatchJob.java
+++ b/src/main/java/com/praise/push/batch/cron/post/jobs/KeywordBatchJob.java
@@ -1,0 +1,20 @@
+package com.praise.push.batch.cron.post.jobs;
+
+import com.praise.push.application.service.KeywordService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KeywordBatchJob {
+    private static final int UPDATE_SIZE = 5;
+
+    private final KeywordService keywordService;
+
+    public void runUpdateSelectedCount() {
+        log.info("Execute Keyword Update Selected Count Job");
+        keywordService.updateSelectedCount(UPDATE_SIZE);
+    }
+}

--- a/src/main/java/com/praise/push/batch/cron/post/scheduler/KeywordBatchScheduler.java
+++ b/src/main/java/com/praise/push/batch/cron/post/scheduler/KeywordBatchScheduler.java
@@ -1,0 +1,17 @@
+package com.praise.push.batch.cron.post.scheduler;
+
+import com.praise.push.batch.cron.post.jobs.KeywordBatchJob;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KeywordBatchScheduler {
+    private final KeywordBatchJob keywordBatchJob;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void runUpdateSelectedCountJob() {
+        keywordBatchJob.runUpdateSelectedCount();
+    }
+}

--- a/src/main/java/com/praise/push/domain/Keyword.java
+++ b/src/main/java/com/praise/push/domain/Keyword.java
@@ -22,4 +22,9 @@ public class Keyword extends BaseTimeEntity {
      * 키워드
      */
     private String keyword;
+
+    /**
+     * 선택된 횟수
+     */
+    private int selectedCount;
 }


### PR DESCRIPTION
- Resolved: #136 

<img width="250" alt="image" src="https://github.com/depromeet/praise-push-server/assets/70641477/cd10f75c-9fbc-4aa0-904c-729bc309e169">

<br>

### 작업 내용
- **QA에 올라온 키워드 추천에 대한 방향성 변경**
    - 기존에는 요청할 때마다 계속 랜덤 추천 키워드가 변경됨.
    - 디자인팀에서 요청한 QA 내용은 같은 날에는 모두가 같은 추천 키워들을 받도록 변경을 요청

<br>

- 생각했던 방향은 하루동안 모두가 동일한 키워드를 봐야한다면 Redis 같은 메모리 디비를 사용하여 캐싱해서 스케쥴러로 하루마다 추천 키워드를 갱신해주는 방법을 생각해봄
- 일단 현재 팀 내에서 Redis를 추가할 수 없는 상황으로 Keyword에 selectedCount라는 필드를 추가
    - 이 필드는 선택된 횟수를 증가시켜 노출이 적게된 키워드도 적절하게 노출되도록 설정

<br>

> 급한 QA건이어서 일단 이렇게 로직을 변경해두었습니다. 추후 변경될 가능성이 있지만, 최대한 클라이언트쪽에서 변화를 주지 않고, 서버에서만 대응할 수 있도록 코드 변경을 해두었습니다.