### PR TITLE
:sparkles: feature: add health check controller

### DIFF
--- a/src/main/java/com/praise/push/adapter/in/web/HealthController.java
+++ b/src/main/java/com/praise/push/adapter/in/web/HealthController.java
@@ -1,0 +1,13 @@
+package com.praise.push.adapter.in.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class HealthController {
+
+    @GetMapping("/health")
+    String checkHealth() {
+        return "Server API Health GOOD";
+    }
+}


### PR DESCRIPTION
- Resolved: #119 

<br>

### 작업내용
- 기존 Load Balancer에서 Health Check API가 따로 존재하지 않아서 임시 방편으로 키워드 추천에 size를 0으로 넣어서 사용하고 있었습니다.
- 이를 대체할 Health Check 전용 API를 생성했습니다.