### PR TITLE
:bug: fix: async monitoring error

### DIFF
--- a/src/main/java/com/praise/push/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/praise/push/common/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.praise.push.common.error;
 import com.praise.push.common.error.exception.PraiseUpException;
 import com.praise.push.common.error.model.ErrorCode;
 import com.praise.push.common.error.model.ErrorEvent;
+import com.praise.push.common.error.model.ErrorRequest;
 import com.praise.push.common.error.model.ErrorResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -48,7 +49,8 @@ public class GlobalExceptionHandler {
             final HttpServletRequest request
     ) {
         log.error("Exception: {}, Request URI: {}", exception.getMessage(), request.getRequestURL());
-        ErrorEvent errorEvent = new ErrorEvent(ErrorCode.INTERNAL_SERVER_ERROR, request, exception);
+        ErrorRequest errorRequest = ErrorRequest.of(request);
+        ErrorEvent errorEvent = new ErrorEvent(ErrorCode.INTERNAL_SERVER_ERROR, errorRequest, exception);
         applicationEventPublisher.publishEvent(errorEvent);
 
         return ErrorResponseDto.build(ErrorCode.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/praise/push/common/error/model/ErrorEvent.java
+++ b/src/main/java/com/praise/push/common/error/model/ErrorEvent.java
@@ -1,10 +1,8 @@
 package com.praise.push.common.error.model;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 public record ErrorEvent(
         ErrorCode errorCode,
-        HttpServletRequest request,
+        ErrorRequest request,
         Exception exception
 ) {
 }

--- a/src/main/java/com/praise/push/common/error/model/ErrorRequest.java
+++ b/src/main/java/com/praise/push/common/error/model/ErrorRequest.java
@@ -1,0 +1,21 @@
+package com.praise.push.common.error.model;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Builder;
+
+@Builder
+public record ErrorRequest(
+    String requestURI,
+    String method,
+    String remoteAddress,
+    String userAgent
+) {
+    public static ErrorRequest of(HttpServletRequest request) {
+        return ErrorRequest.builder()
+                .requestURI(request.getRequestURI())
+                .method(request.getMethod())
+                .remoteAddress(request.getRemoteAddr())
+                .userAgent(request.getHeader("User-Agent"))
+                .build();
+    }
+}


### PR DESCRIPTION
> 에러 콘솔이 계속 찍혀서 먼저 반영을 하겠습니다.

- Resolved: #150 

<br>

### 꾸준히 발생하던 에러

```
2024-01-29T22:30:44.886+09:00 ERROR 59250 --- [io-8080-exec-10] c.p.p.c.error.GlobalExceptionHandler     : Exception: Failed to convert value of type 'java.lang.String' to required type 'java.lang.Long'; For input string: "undefined", Request URI: http://api.praise-up.app/praise-up/api/v1/posts/undefined
2024-01-29T22:30:44.887+09:00 ERROR 59250 --- [       task-420] .a.i.SimpleAsyncUncaughtExceptionHandler : Unexpected exception occurred invoking async method: public void com.praise.push.common.monitoring.SlackMonitoringProvider.pushError(com.praise.push.common.error.model.ErrorEvent)

java.lang.IllegalStateException: The request object has been recycled and is no longer associated with this facade
at org.apache.catalina.connector.RequestFacade.checkFacade(RequestFacade.java:855) ~[tomcat-embed-core-10.1.15.jar!/:na]
at org.apache.catalina.connector.RequestFacade.getContextPath(RequestFacade.java:571) ~[tomcat-embed-core-10.1.15.jar!/:na]
at jakarta.servlet.http.HttpServletRequestWrapper.getContextPath(HttpServletRequestWrapper.java:149) ~[tomcat-embed-core-10.1.15.jar!/:na]
at com.praise.push.common.monitoring.SlackMonitoringProvider.createSlackAttachments(SlackMonitoringProvider.java:45) ~[classes!/:0.0.1-SNAPSHOT]
at com.praise.push.common.monitoring.SlackMonitoringProvider.createSlackMessage(SlackMonitoringProvider.java:34) ~[classes!/:0.0.1-SNAPSHOT]
at com.praise.push.common.monitoring.SlackMonitoringProvider.pushError(SlackMonitoringProvider.java:24) ~[classes!/:0.0.1-SNAPSHOT]
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:343) ~[spring-aop-6.0.13.jar!/:6.0.13]
at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196) ~[spring-aop-6.0.13.jar!/:6.0.13]
at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-6.0.13.jar!/:6.0.13]
at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) ~[spring-aop-6.0.13.jar!/:6.0.13]
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[na:na]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
```

### 원인
- 현재 Slack 비동기 처리를 위해서 HttpServletRequest 객체를 쓰고 있는데, 이는 Response가 가는 순간 생명주기가 끝난다.
- 그래서 비동기 처리가 완료되기 전에 Servlet 객체의 생명주기가 먼저 끝나버려서 발생한 오류

### 참고
- [비동기 처리 과정에서 발생한 에러 해결](https://velog.io/@789456jang/%EB%B9%84%EB%8F%99%EA%B8%B0-%EC%B2%98%EB%A6%AC-%EA%B3%BC%EC%A0%95%EC%97%90%EC%84%9C-%EB%B0%9C%EC%83%9D%ED%95%9C-%EC%97%90%EB%9F%AC-%ED%95%B4%EA%B2%B0)